### PR TITLE
Add README.md to C# NuGet package

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-131-fc081b5b
-Your prepared working directory: /tmp/gh-issue-solver-1761889186579
-
-Proceed.


### PR DESCRIPTION
## Summary

This PR fixes the NuGet.org warning "Your package is missing a README" by properly including the README.md file in the C# NuGet package.

### Changes Made

- Added `<PackageReadmeFile>README.md</PackageReadmeFile>` property to the .csproj file
- Added README.md to the package via `<None Include="../README.md" Pack="true" PackagePath="/" />`
- Bumped package version from 0.11.0 to 0.11.1
- Updated PackageReleaseNotes to describe this improvement

### Technical Details

The solution follows the same pattern used by other language packages in this repository:
- Python's `pyproject.toml` has `readme = "README.md"`
- The C# implementation now uses the NuGet-standard `<PackageReadmeFile>` property

### Verification

✅ Local build successful  
✅ All 105 tests passing  
✅ Package created with README.md included (verified with unzip)  
✅ README.md content confirmed in package

## Test Plan

- [x] Build succeeds: `dotnet build --configuration Release`
- [x] Tests pass: `dotnet test --configuration Release`
- [x] Package builds: `dotnet pack --configuration Release`
- [x] README.md included in .nupkg (verified with unzip -l)
- [ ] CI checks pass on GitHub
- [ ] After merge to main, new version 0.11.1 published to NuGet.org
- [ ] NuGet.org displays README without warning

## Issue Reference

Fixes #131

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)