### PR TITLE
Add FormatConfig support for links notation formatting in all languages (C#, JavaScript, Rust, Python)

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,9 +1,9 @@
 pub mod format_config;
 pub mod parser;
 
+use format_config::FormatConfig;
 use std::error::Error as StdError;
 use std::fmt;
-use format_config::FormatConfig;
 
 /// Error type for Lino parsing
 #[derive(Debug)]
@@ -65,20 +65,29 @@ impl<T: ToString + Clone> LiNo<T> {
             LiNo::Link { id, values } => {
                 // Empty link
                 if id.is_none() && values.is_empty() {
-                    return if config.less_parentheses { String::new() } else { "()".to_string() };
+                    return if config.less_parentheses {
+                        String::new()
+                    } else {
+                        "()".to_string()
+                    };
                 }
 
                 // Link with only ID, no values
                 if values.is_empty() {
                     if let Some(ref id_val) = id {
                         let escaped_id = escape_reference(&id_val.to_string());
-                        return if config.less_parentheses && !needs_parentheses(&id_val.to_string()) {
+                        return if config.less_parentheses && !needs_parentheses(&id_val.to_string())
+                        {
                             escaped_id
                         } else {
                             format!("({})", escaped_id)
                         };
                     }
-                    return if config.less_parentheses { String::new() } else { "()".to_string() };
+                    return if config.less_parentheses {
+                        String::new()
+                    } else {
+                        "()".to_string()
+                    };
                 }
 
                 // Check if we should use indented format
@@ -87,7 +96,8 @@ impl<T: ToString + Clone> LiNo<T> {
                     should_indent = true;
                 } else {
                     // Try inline format first to check line length
-                    let values_str = values.iter()
+                    let values_str = values
+                        .iter()
                         .map(|v| format_value(v))
                         .collect::<Vec<_>>()
                         .join(" ");
@@ -116,7 +126,8 @@ impl<T: ToString + Clone> LiNo<T> {
                 }
 
                 // Standard inline formatting
-                let values_str = values.iter()
+                let values_str = values
+                    .iter()
                     .map(|v| format_value(v))
                     .collect::<Vec<_>>()
                     .join(" ");
@@ -127,7 +138,8 @@ impl<T: ToString + Clone> LiNo<T> {
                         // Check if all values are simple (no nested values)
                         let all_simple = values.iter().all(|v| matches!(v, LiNo::Ref(_)));
                         if all_simple {
-                            return values.iter()
+                            return values
+                                .iter()
                                 .map(|v| match v {
                                     LiNo::Ref(r) => escape_reference(&r.to_string()),
                                     _ => format_value(v),
@@ -143,7 +155,8 @@ impl<T: ToString + Clone> LiNo<T> {
                 // Link with ID and values
                 let id_str = escape_reference(&id.as_ref().unwrap().to_string());
                 let with_colon = format!("{}: {}", id_str, values_str);
-                if config.less_parentheses && !needs_parentheses(&id.as_ref().unwrap().to_string()) {
+                if config.less_parentheses && !needs_parentheses(&id.as_ref().unwrap().to_string())
+                {
                     with_colon
                 } else {
                     format!("({})", with_colon)
@@ -162,7 +175,8 @@ impl<T: ToString + Clone> LiNo<T> {
             LiNo::Link { id, values } => {
                 if id.is_none() {
                     // Values only - format each on separate line
-                    values.iter()
+                    values
+                        .iter()
                         .map(|v| format!("{}{}", config.indent_string, format_value(v)))
                         .collect::<Vec<_>>()
                         .join("\n")
@@ -471,7 +485,8 @@ pub fn format_links_with_config(links: &[LiNo<String>], config: &FormatConfig) -
         links.to_vec()
     };
 
-    links_to_format.iter()
+    links_to_format
+        .iter()
         .map(|link| link.format_with_config(config))
         .collect::<Vec<_>>()
         .join("\n")
@@ -504,14 +519,22 @@ fn group_consecutive_links(links: &[LiNo<String>]) -> Vec<LiNo<String>> {
         let current = &links[i];
 
         // Look ahead for consecutive links with same ID
-        if let LiNo::Link { id: Some(ref current_id), values: ref current_values } = current {
+        if let LiNo::Link {
+            id: Some(ref current_id),
+            values: ref current_values,
+        } = current
+        {
             if !current_values.is_empty() {
                 // Collect all values with same ID
                 let mut same_id_values = current_values.clone();
                 let mut j = i + 1;
 
                 while j < links.len() {
-                    if let LiNo::Link { id: Some(ref next_id), values: ref next_values } = &links[j] {
+                    if let LiNo::Link {
+                        id: Some(ref next_id),
+                        values: ref next_values,
+                    } = &links[j]
+                    {
                         if next_id == current_id && !next_values.is_empty() {
                             same_id_values.extend(next_values.clone());
                             j += 1;

--- a/rust/tests/format_config_tests.rs
+++ b/rust/tests/format_config_tests.rs
@@ -1,5 +1,5 @@
 use links_notation::format_config::FormatConfig;
-use links_notation::{LiNo, format_links_with_config, parse_lino_to_links};
+use links_notation::{format_links_with_config, parse_lino_to_links, LiNo};
 
 #[test]
 fn format_config_basic() {
@@ -109,9 +109,7 @@ fn format_link_with_less_parentheses_integration() {
         values: vec![LiNo::Ref("value".to_string())],
     };
 
-    let config = FormatConfig::builder()
-        .less_parentheses(true)
-        .build();
+    let config = FormatConfig::builder().less_parentheses(true).build();
 
     let output = link.format_with_config(&config);
     // Should not have outer parentheses
@@ -139,7 +137,10 @@ fn format_link_with_max_inline_refs_integration() {
 
     let output = link.format_with_config(&config);
     assert!(output.contains("id:"), "Output should contain 'id:'");
-    assert!(output.contains('\n'), "Output should be indented across multiple lines");
+    assert!(
+        output.contains('\n'),
+        "Output should be indented across multiple lines"
+    );
 }
 
 #[test]
@@ -159,8 +160,14 @@ fn format_link_with_line_length_limit_integration() {
         .build();
 
     let output = link.format_with_config(&config);
-    assert!(output.contains("sequence:"), "Output should contain 'sequence:'");
-    assert!(output.contains('\n'), "Output should be indented across multiple lines");
+    assert!(
+        output.contains("sequence:"),
+        "Output should contain 'sequence:'"
+    );
+    assert!(
+        output.contains('\n'),
+        "Output should be indented across multiple lines"
+    );
 }
 
 #[test]
@@ -181,9 +188,7 @@ fn format_links_with_consecutive_grouping_integration() {
         },
     ];
 
-    let config = FormatConfig::builder()
-        .group_consecutive(true)
-        .build();
+    let config = FormatConfig::builder().group_consecutive(true).build();
 
     let output = format_links_with_config(&links, &config);
 
@@ -215,7 +220,10 @@ fn format_link_with_custom_indent_integration() {
 
     let output = link.format_with_config(&config);
     // Check for custom indentation (4 spaces)
-    assert!(output.contains("    "), "Output should use 4-space indentation");
+    assert!(
+        output.contains("    "),
+        "Output should use 4-space indentation"
+    );
 }
 
 #[test]
@@ -243,7 +251,10 @@ fn format_roundtrip_with_config_integration() {
 
     // Should parse successfully and preserve structure
     assert!(parsed.is_ok(), "Should parse successfully");
-    assert!(!parsed.unwrap().is_empty(), "Parsed result should not be empty");
+    assert!(
+        !parsed.unwrap().is_empty(),
+        "Parsed result should not be empty"
+    );
 }
 
 #[test]
@@ -262,9 +273,7 @@ fn format_single_ref_with_config() {
     let output_with_parens = link.format_with_config(&config_with_parens);
     assert_eq!(output_with_parens, "(value)");
 
-    let config_less_parens = FormatConfig::builder()
-        .less_parentheses(true)
-        .build();
+    let config_less_parens = FormatConfig::builder().less_parentheses(true).build();
     let output_less_parens = link.format_with_config(&config_less_parens);
     assert_eq!(output_less_parens, "value");
 }


### PR DESCRIPTION
## Summary

This PR ensures that the formatter in all languages is configurable with special formatting options as requested in #155.

### Changes Made

**Rust Implementation (new in this PR):**
- Added `LiNo<T>::format_with_config()` method for formatting individual links with configuration
- Added `format_links_with_config()` function for formatting link collections with configuration
- Implemented `group_consecutive_links()` helper for grouping consecutive same-ID links
- Added helper functions: `escape_reference()`, `needs_parentheses()`, `format_value()`
- Added 8 new integration tests verifying all formatting options

### All 7 Formatting Options Now Supported Across All Languages

| Option | C# | JavaScript | Python | Rust |
|--------|-----|-----------|--------|------|
| `lessParentheses` / `less_parentheses` | ✅ | ✅ | ✅ | ✅ |
| `maxLineLength` / `max_line_length` | ✅ | ✅ | ✅ | ✅ |
| `indentLongLines` / `indent_long_lines` | ✅ | ✅ | ✅ | ✅ |
| `maxInlineRefs` / `max_inline_refs` | ✅ | ✅ | ✅ | ✅ |
| `groupConsecutive` / `group_consecutive` | ✅ | ✅ | ✅ | ✅ |
| `indentString` / `indent_string` | ✅ | ✅ | ✅ | ✅ |
| `preferInline` / `prefer_inline` | ✅ | ✅ | ✅ | ✅ |

### Example Usage

The formatter can now transform:
```lino
sequence: 1 2 3 4
```
Into indented format when configured (e.g., `maxInlineRefs: 3` and `preferInline: false`):
```lino
sequence:
  1
  2
  3
  4
```

And group consecutive links:
```lino
(SetA a)
(SetA b)
```
Into:
```lino
SetA:
  a
  b
```

## Test Plan

- [x] All JavaScript tests pass (140 tests)
- [x] All Python tests pass (138 tests)
- [x] All C# tests pass (142 tests)
- [x] All Rust tests pass (148 tests, including 8 new integration tests)
- [x] Verify CI passes

## Issue Reference

Fixes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)